### PR TITLE
Include firewalld only if manage_firewall is true

### DIFF
--- a/manifests/common/redhat.pp
+++ b/manifests/common/redhat.pp
@@ -24,7 +24,7 @@ class slurm::common::redhat inherits slurm::common {
     require => Yum::Group[$slurm::params::groupinstall],
   }
 
-  if versioncmp($facts['os']['release']['major'], '7') >= 0 {
+  if $slurm::manage_firewall and versioncmp($facts['os']['release']['major'], '7') >= 0 {
     include ::firewalld
   }
 


### PR DESCRIPTION
We are using [puppetlabs/firewall](https://forge.puppet.com/puppetlabs/firewall) module to setup firewall on our hosts. The problem is that it conflicts with [crayfishx/firewalld](https://forge.puppet.com/crayfishx/firewalld) module which slurm module includes independently of `manage_firewall` parameter value. So this changes should fix the case when users want to setup firewall using another module.