### PR TITLE
Fix startup error when acct enforce list is empty

### DIFF
--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -202,7 +202,11 @@ ResumeTimeout=<%= scope['slurm::resumetimeout'] %>
 ##################
 ### Accounting ###
 ##################
+<% if scope['slurm::acct_storageenforce'].empty? -%>
+# AccountingStorageEnforce=qos,limits,associations
+<% else -%>
 AccountingStorageEnforce=<%= scope['slurm::acct_storageenforce'].join(',') %>
+<% end -%>
 AccountingStorageHost=<%= scope['slurm::controlmachine'] %>
 AccountingStorageLoc=slurm
 #AccountingStoragePass=


### PR DESCRIPTION
An empty value in AccountingStorageEnforce parameter causes
slurm daemon to fail on start. If no enforcement is desired,
this parameter should be commented out.