### PR TITLE
Optionally send slurmd, slurmctld and slurmdbd  logs to syslog

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,7 +230,10 @@
 # @param selecttype_params        [Array  ]     Default: [ 'CR_Core_Memory', 'CR_CORE_DEFAULT_DIST_BLOCK' ]
 
 # @param slurmctlddebug           [String ]     Default: 'info'
+# @param slurmctlddebugsyslog     [String ]     Default: ''
 # @param slurmddebug              [String ]     Default: 'info'
+# @param slurmddebugsyslog        [String ]     Default: ''
+# @param slurmdbddebugsyslog      [String ]     Default: ''
 
 # @param slurmctldport            [Integer]     Default: 6817
 # @param slurmdport               [Integer]     Default: 6818
@@ -552,6 +555,9 @@ class slurm(
   # Log details
   String  $slurmctlddebug                 = $slurm::params::slurmctlddebug,
   String  $slurmddebug                    = $slurm::params::slurmddebug,
+  String  $slurmctlddebugsyslog           = $slurm::params::slurmctlddebugsyslog,
+  String  $slurmddebugsyslog              = $slurm::params::slurmddebugsyslog,
+  String  $slurmdbddebugsyslog            = $slurm::params::slurmdbddebugsyslog,
   # Ports
   Integer $slurmctldport                  = $slurm::params::slurmctldport,
   Integer $slurmdport                     = $slurm::params::slurmdport,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -235,8 +235,11 @@ $selecttype              = 'cons_res' # in ['bluegene','cons_res','cray','linear
 $selecttype_params       = [ 'CR_Core_Memory', 'CR_CORE_DEFAULT_DIST_BLOCK' ]
 # Log details
 $slurmdbddebug           = 'info'
+$slurmdbddebugsyslog     = ''
 $slurmctlddebug          = 'info'
+$slurmctlddebugsyslog    = ''
 $slurmddebug             = 'info'
+$slurmddebugsyslog       = ''
 # Ports
 $slurmctldport           = 6817
 $slurmdport              = 6818

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -136,6 +136,19 @@ SlurmctldDebug=<%= scope['slurm::slurmctlddebug'] %>
 SlurmctldLogFile=<%= scope['slurm::params::logdir'] %>/slurmctld.log
 SlurmdDebug=<%= scope['slurm::slurmddebug'] %>
 SlurmdLogFile=<%= scope['slurm::params::logdir'] %>/slurmd.log
+
+<% if scope['slurm::slurmddebugsyslog'].empty? -%>
+#SlurmdSyslogDebug=
+<% else -%>
+SlurmdSyslogDebug=<%= scope['slurm::slurmddebugsyslog']%>
+<% end -%>
+
+<% if scope['slurm::slurmctlddebugsyslog'].empty? -%>
+#SlurmctldSyslogDebug=
+<% else -%>
+SlurmctldSyslogDebug=<%= scope['slurm::slurmctlddebugsyslog']%>
+<% end -%>
+
 #SlurmSchedLogFile=
 #SlurmSchedLogLevel=
 

--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -30,6 +30,13 @@ DebugLevel=<%= scope['slurm::slurmdbd::debuglevel'] %>
 DebugFlags=<%= scope['slurm::slurmdbd::debugflags'].join(',') %>
 <% end -%>
 LogFile=<%= scope['slurm::logdir'] %>/slurmdbd.log
+
+<% if scope['slurm::slurmdbddebugsyslog'].empty? -%>
+#DebugLevelSyslog=
+<% else -%>
+DebugLevelSyslog=<%= scope['slurm::slurmdbddebugsyslog']%>
+<% end -%>
+
 #PidFile=/var/run/slurmdbd.pid
 # Authentication for communications with the other Slurm components
 AuthType=auth/<%= scope['slurm::authtype'] %>


### PR DESCRIPTION
This commit adds support to configure slurm daemons to send logs to syslog, by default no logs are sent to syslog.

