### PR TITLE
Fixed an issue where the accounting module would crash if a partition had no priority

### DIFF
--- a/manifests/accounting.pp
+++ b/manifests/accounting.pp
@@ -44,12 +44,12 @@ inherits slurm::params
 
   ### QOS
   # Make the default qos out of the partitions definitions
-  $slurm::partitions.each |$partition, $h| {
-    if $partition != 'DEFAULT' {
+  $slurm::partitions.each |$name, $description| {
+    if $name != 'DEFAULT' and has_key($description, 'priority') {
       $qosname = "qos-${partition}"
       slurm::acct::qos{ $qosname:
         ensure   => $ensure,
-        priority => ($h['priority'] + 0),
+        priority => ($description['priority'] + 0),
       }
       # Eventually complete it with entries from the $slurm::qos hash
       unless empty($qos) {


### PR DESCRIPTION
I have been reading through the documentation and code in order to figure out how to add a cluster to the surmdbd's account management. I've found [accounting.pp](https://github.com/ULHPC/puppet-slurm/blob/0f4846b7716eba3aba6f7cbaf507b17d47eda1cf/manifests/accounting.pp) but when I include it in a node by adding `include slurm::accounting` to it the run errors out with the message:

```
Error: Could not retrieve catalog from remote server: Error 500 on server: Server Error: Evaluation Error: The value '' cannot be converted to Numeric. (file: /etc/puppetlabs/code/environments/production/modules/slurm/manifests/accounting.pp, line:52, column: 22) on node xx.
```

I figured out that this was due to the code assumed that every partition had a priority associated with it and patched out that assumption.