### PR TITLE
Make the slurmctl class require that the config is present

### DIFF
--- a/manifests/slurmctld.pp
+++ b/manifests/slurmctld.pp
@@ -67,6 +67,7 @@ class slurm::slurmctld inherits slurm
       pattern    => $slurm::params::controller_processname,
       hasrestart => $slurm::params::hasrestart,
       hasstatus  => $slurm::params::hasstatus,
+      require    => Class['::slurm::config'],
     }
 
     # if $slurm::ensure == 'present' {


### PR DESCRIPTION
I found that `slurm.conf` was not deployed on puppet nodes configured to `import slurm::slurmctld`. In order to remedy this I made the slurmctld service require the class `::slurm::config` before being deployed.