### PR TITLE
Make the accounting tasks require that the config is present

### DIFF
--- a/manifests/acct/mgr.pp
+++ b/manifests/acct/mgr.pp
@@ -118,6 +118,7 @@ define slurm::acct::mgr(
       command => $cmd,
       onlyif  => $check_onlyif,
       unless  => $check_unless,
+      require => Class['::slurm::config'],
     }
   }
   else {


### PR DESCRIPTION
I found that `slurm.conf` was not deployed on puppet nodes configured to `import slurm::accounting`. In order to remedy this I made the execution of account management commands depend on the present of a slurm config.