### PR TITLE
Correct base download URL to download.schedmd.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,6 @@ This definition takes care of downloading the SLURM sources for a given version 
      - Ensure the presence (or absence) of building
 * `target` [String] Default: `/usr/local/src`
      - Target directory for the downloaded sources
-* `archived` [Boolean] Default: `false`
-     - Whether the sources tar.bz2 has been archived or not.Thus by default, it is assumed that the provided version is the latest version (from <https://www.schedmd.com/downloads/latest/>).
-     - If set to `true`, the sources will be download from <https://www.schedmd.com/downloads/archive/>
 * `checksum_type` [String] Default: `md5`
      - archive file checksum type (none|md5|sha1|sha2|sh256|sha384| sha512).
 * `checksum_verify` [Boolean] Default: false
@@ -269,7 +266,7 @@ This definition takes care of downloading the SLURM sources for a given version 
 * `checksum` [String] Default: ''
      -  archive file checksum (match checksum_type)
 
-_Example 1_: Downloading version 17.11.12 (latest at the time of writing) of SLURM
+_Example_: Downloading version 17.11.12 (latest at the time of writing) of SLURM
 
 ```ruby
 slurm::download { '17.11.12':
@@ -279,15 +276,6 @@ slurm::download { '17.11.12':
 }
 ```
 
-_Example 2_: Downloading archived version 16.05.10 version of SLURM
-
-```ruby
-slurm::download { 'slurm-16.05.10.tar.bz2':
-  ensure   => 'present',
-  archived => true,
-  target   => '/usr/local/src/',
-}
-```
 
 ### Definition `slurm::build`
 

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -18,12 +18,6 @@
 #          Ensure the presence (or absence) of building
 # @param target [String] Default: '/usr/local/src'
 #          Target directory for the downloaded sources
-# @param archived [Boolean] Default: false
-#          Whether the sources tar.bz2 has been archived or not.
-#          Thus by default, it is assumed that the provided version is the
-#          latest version (from https://www.schedmd.com/downloads/latest/).
-#          If set to true, the sources will be download from
-#             https://www.schedmd.com/downloads/archive/
 # @param checksum_type [String] Default: 'md5'
 #          archive file checksum type (none|md5|sha1|sha2|sh256|sha384| sha512).
 # @param checksum_verify [Boolean] Default: false
@@ -37,14 +31,12 @@
 #        ensure        => 'present',
 #        checksum      => '42f0a5dbe34210283f474328ac6e8d5267dc2386',
 #        checksum_type => 'sha1',
-#        archived      => true,
 #        target        => '/usr/local/src/',
 #   }
 #
 define slurm::download(
   String  $ensure          = $slurm::params::ensure,
   String  $target          = $slurm::params::srcdir,
-  Boolean $archived        = $slurm::params::src_archived,
   String  $checksum        = '',
   String  $checksum_type   = $slurm::params::src_checksum_type,
   Boolean $checksum_verify = false,
@@ -65,11 +57,9 @@ define slurm::download(
     $archive = "slurm-${version}.tar.bz2"
   }
   else { fail("Wrong specification for ${module_name}") }
+
   # URL from where to download the sources
-  $url = $archived ? {
-    true    => "${slurm::params::download_baseurl}/${slurm::params::download_archivedir}/${archive}",
-    default => "${slurm::params::download_baseurl}/${slurm::params::download_latestdir}/${archive}"
-  }
+  $url = "${slurm::params::download_baseurl}/${archive}"
   # Absolute path to the downloaded source file
   $path =  "${target}/${archive}"
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,12 +58,6 @@
 #          Do we perform the install of the Slurm packages or not?
 # @param wrappers                 [Array]       Default: [ 'slurm-openlava',  'slurm-torque' ]
 #          Extra wrappers/package to install (ex: openlava/LSF wrapper, Torque/PBS wrappers)
-# @param src_archived             [Boolean]     Default: false
-#          Whether the sources tar.bz2 has been archived or not.
-#          Thus by default, it is assumed that the provided version is the
-#          latest version (from https://www.schedmd.com/downloads/latest/).
-#          If set to true, the sources will be download from
-#             https://www.schedmd.com/downloads/archive/
 # @param src_checksum             [String]      Default: ''
 #           archive file checksum (match checksum_type)
 # @param src_checksum_type        [String]      Default: 'md5'
@@ -459,7 +453,6 @@ class slurm(
   # Slurm source building
   Boolean $do_build                       = $slurm::params::do_build,
   Boolean $do_package_install             = $slurm::params::do_package_install,
-  Boolean $src_archived                   = $slurm::params::src_archived,
   String  $src_checksum                   = $slurm::params::src_checksum,
   String  $src_checksum_type              = $slurm::params::src_checksum_type,
   String  $srcdir                         = $slurm::params::srcdir,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,7 +22,6 @@ class slurm::install {
     slurm::download { $slurm::version :
       ensure        => $slurm::ensure,
       target        => $slurm::srcdir,
-      archived      => $slurm::src_archived,
       checksum      => $slurm::src_checksum,
       checksum_type => $slurm::src_checksum_type,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -413,15 +413,10 @@ $version = '17.11.12'
 $src_checksum      = '94fb13b509d23fcf9733018d6c961ca9'
 $src_checksum_type = 'md5'
 # From where the Slurm sources can be downloaded
-$download_baseurl    = 'https://www.schedmd.com/downloads'
-$download_latestdir  = 'latest'
-$download_archivedir = 'archive'
-# Whether the remote source archive has been already archived  - this
-# unfortunately changes the URL to download from
+$download_baseurl    = 'https://download.schedmd.com/slurm/'
 
 $do_build            = true
 $do_package_install  = true
-$src_archived        = false
 # Where to place the sources
 $srcdir = $::operatingsystem ? {
   default => '/usr/local/src'

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -51,10 +51,7 @@ define slurm::plugin(
   # }
   # else { fail("Wrong specification for ${module_name}") }
   # # URL from where to download the sources
-  # $url = $archived ? {
-  #   true    => "${slurm::params::download_baseurl}/${slurm::params::download_archivedir}/${archive}",
-  #   default => "${slurm::params::download_baseurl}/${slurm::params::download_latestdir}/${archive}"
-  # }
+  # $url =  "${slurm::params::download_baseurl}/${archive}"
   # # Absolute path to the downloaded source file
   # $path =  "${target}/${archive}"
 

--- a/templates/slurm_packages_build.sh.erb
+++ b/templates/slurm_packages_build.sh.erb
@@ -130,8 +130,7 @@ service_restart() {
 # Download the sources
 ##
 download_slurm(){
-    download_url="${DOWNLOAD_BASEURL}/latest/${SLURM_ARCHIVE}"
-    download_url_archive="${DOWNLOAD_BASEURL}/archive/${SLURM_ARCHIVE}"
+    download_url="${DOWNLOAD_BASEURL}/${SLURM_ARCHIVE}"
     download_archive="${SRC_DIR}/${SLURM_ARCHIVE}"
 
     if [ ! -d "${SRC_DIR}" ]; then
@@ -141,7 +140,6 @@ download_slurm(){
     if [ ! -f "${download_archive}" ]; then
         curl -o ${SRC_DIR}/${SLURM_ARCHIVE} ${download_url}
     fi
-
 }
 
 ###

--- a/tests/vagrant/puppet/hieradata/defaults.yaml
+++ b/tests/vagrant/puppet/hieradata/defaults.yaml
@@ -12,7 +12,6 @@ slurm::builddir: '/vagrant/tests/vagrant/rpmbuild'
 #slurm::version: '17.11.12'
 slurm::uid: 900
 slurm::gid: 900
-#slurm::src_archived: false
 #slurm::src_checksum: '94fb13b509d23fcf9733018d6c961ca9'
 slurm::service_manage: true
 


### PR DESCRIPTION
The two different archives of `latest` and `archived` no longer exist
on schedmd.com. Now they only have what was previously called
latest. This commit removes the argument "archived" from the public
interface of the module and correctl the base url to reflect this
change.

This pull request resolves issue #27.