### PR TITLE
target cannot be an empty string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.2.7
+  - rvm: 2.6
     env: PUPPET_GEM_VERSION="~> 4.4.0"
   # - rvm: 2.1.9
   #   env: PUPPET_GEM_VERSION="~> 4.10.0"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,6 +45,7 @@ class slurm::config {
     } else {
       File[$pluginsdir] {
         ensure => 'directory',
+        target => 'notlink',
       }
     }
     file { $pluginsdir:


### PR DESCRIPTION
If pluginsdir_target isn't set then target needs to be set to 'notlink'