### PR TITLE
Only set :is_vagrant if :is_virtual is present

### DIFF
--- a/lib/facter/is_vagrant.rb
+++ b/lib/facter/is_vagrant.rb
@@ -1,5 +1,6 @@
 Facter.add(:is_vagrant) do
+  confine :is_virtual => true
   setcode do
-    Facter[:is_virtual].value && File.directory?('/vagrant')
+    File.directory?('/vagrant')
   end
 end


### PR DESCRIPTION
Check if `:is_virtual` is true before executing the `setcode` block.

On my system `:is_virtual` is not present, trying to access Facter[:is_virtual].value when is not assigned breaks ALL facts.