### PR TITLE
Replace stahnma/epel by puppet-epel

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See [`metadata.json`](https://github.com/ULHPC/puppet-slurm/blob/devel/metadata.
 * [puppetlabs/inifile](https://forge.puppetlabs.com/puppetlabs/inifile)
 * [puppet/archive](https://forge.puppetlabs.com/puppet/archive)
 * [puppet/yum](https://forge.puppetlabs.com/puppet/yum)
-* [stahnma/epel](https://forge.puppetlabs.com/stahnma/epel)
+* [puppet/epel](https://forge.puppet.com/puppet/epel)
 * [bodgit/rngd](https://forge.puppetlabs.com/bodgit/rngd)
 * [ghoneycutt/pam](https://forge.puppetlabs.com/ghoneycutt/pam)
 

--- a/metadata.json
+++ b/metadata.json
@@ -41,8 +41,8 @@
       "version_requirement": ">=1.3.0 <2.0.0"
     },
     {
-      "name": "stahnma-epel",
-      "version_requirement": ">=1.2.2 <2.0.0"
+      "name": "puppet-epel",
+      "version_requirement": ">=1.2.2 <3.0.1"
     },
     {
       "name": "svarrette-ulimit",


### PR DESCRIPTION
stahnma/epel module has been deprecated by its author since February 20, 2020.

The reason given was:
Transferred to Vox Pupuli

The author has suggested puppet-epel as its replacement.