### PR TITLE
Build slurm with pmix pre-installed

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -28,6 +28,8 @@
 # @param without [Array] Default: [] -- see slurm::params
 #          see https://github.com/SchedMD/slurm/blob/master/slurm.spec
 #          List of --without build options to pass to rpmbuild
+# @param pmix_install_path [String] Default: [] -- see slurm::params
+#          Path where PMIx is installed
 #
 # @example Building version 19.05.3-2 of SLURM
 #

--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -60,11 +60,12 @@
 #      slurm-torque-19.05.3-2.el7.x86_64.rpm
 #
 define slurm::build(
-  String  $ensure  = $slurm::params::ensure,
-  String  $srcdir  = $slurm::params::srcdir,
-  String  $dir     = $slurm::params::builddir,
-  Array   $with    = $slurm::params::build_with,
-  Array   $without = $slurm::params::build_without,
+  String  $ensure            = $slurm::params::ensure,
+  String  $srcdir            = $slurm::params::srcdir,
+  String  $dir               = $slurm::params::builddir,
+  Array   $with              = $slurm::params::build_with,
+  Array   $without           = $slurm::params::build_without,
+  String  $pmix_install_path = $slurm::params::pmix_install_path,
 )
 {
   include ::slurm::params
@@ -105,7 +106,7 @@ define slurm::build(
       Class['::slurm::pmix'] -> Exec[$buildname]
       # Slurm::Pmix::Install[$slurm::pmix::version] -> Exec[$buildname]
     }
-    $define_pmix = "--define \"_with_pmix --with-pmix=${slurm::params::pmix_install_path}\""
+    $define_pmix = "--define \"_with_pmix --with-pmix=${$pmix_install_path}\""
   } else {
     $define_pmix = ''
   }

--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -108,7 +108,7 @@ define slurm::build(
       Class['::slurm::pmix'] -> Exec[$buildname]
       # Slurm::Pmix::Install[$slurm::pmix::version] -> Exec[$buildname]
     }
-    $define_pmix = "--define \"_with_pmix --with-pmix=${$pmix_install_path}\""
+    $define_pmix = "--define \"_with_pmix --with-pmix=${pmix_install_path}\""
   } else {
     $define_pmix = ''
   }


### PR DESCRIPTION
In some HPC site, the PMIx software could be installed in a external path. No need puppet-slurm compile pmix again, but must be rpmbuild with pmix that is located in a external path.