### PR TITLE
Allow slurmdport and slurmctldport to be Strings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -642,8 +642,8 @@ class slurm(
   String  $slurmdsyslogdebug              = $slurm::params::slurmdsyslogdebug,
   String  $slurmdbddebugsyslog            = $slurm::params::slurmdbddebugsyslog,
   # Ports
-  Integer $slurmctldport                  = $slurm::params::slurmctldport,
-  Integer $slurmdport                     = $slurm::params::slurmdport,
+  Variant[Integer,String] $slurmctldport  = $slurm::params::slurmctldport,
+  Variant[Integer,String] $slurmdport     = $slurm::params::slurmdport,
   # Timeout
   Integer $slurmctldtimeout               = $slurm::params::slurmctldtimeout,
   Integer $slurmdtimeout                  = $slurm::params::slurmdtimeout,


### PR DESCRIPTION
As per https://slurm.schedmd.com/slurm.conf.html,
port parameters can be port ranges.