### PR TITLE
Add AccountingStoreFlags, remove AccountingStoreJobComment 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,8 @@
 # @param accountingstoragehost    [String]      Default: $:hostname
 # @param accountingstoragetres    [String]      Default: ''
 #
+# @param accountingstoreflags [Array] Default: []
+#
 # @param acctgatherenergytype    [String]      Default: 'none'
 #          Identifies the plugin to be used for energy consumption accounting
 #          Elligible values in [ 'none', 'ipmi', 'rapl' ]
@@ -543,6 +545,7 @@ class slurm(
   # String  $backupaddr                     = $slurm::params::backupaddr,
   # String  $controlmachine                 = $slurm::params::controlmachine,
   # String  $controladdr                    = $slurm::params::controladdr,
+  Array   $accountingstoreflags           = $slurm::params::accountingstoreflags,
   String  $accountingstoragehost          = $slurm::params::accountingstoragehost,
   Array   $accountingstorageexternalhost  = $slurm::params::accountingstorageexternalhost,
   #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -141,6 +141,7 @@ class slurm::params {
   # Accounting storage slurmdbd server
   $accountingstoragehost   = $::hostname
   $accountingstorageexternalhost = []
+  $accountingstoreflags = []
   # Authentication method for communications between Slurm components.
   $authtype                = 'munge' # in [ 'none', 'munge' ]
   $authinfo                = ''

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -293,7 +293,6 @@ AccountingStorageHost=<%= scope['slurm::accountingstoragehost'] %>
 #AccountingStoragePort=
 AccountingStorageType=accounting_storage/slurmdbd
 #AccountingStorageUser=
-AccountingStoreJobComment=YES
 
 <% if scope['slurm::accountingstoreflags'].empty? -%>
 #AccountingStoreFlags=

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -295,6 +295,12 @@ AccountingStorageType=accounting_storage/slurmdbd
 #AccountingStorageUser=
 AccountingStoreJobComment=YES
 
+<% if scope['slurm::accountingstoreflags'].empty? -%>
+#AccountingStoreFlags=
+<% else -%>
+AccountingStoreFlags=<%= scope['slurm::accountingstoreflags'].join(',') %>
+<% end -%>
+
 AcctGatherEnergyType=acct_gather_energy/<%=         scope['slurm::acctgatherenergytype'] %>
 AcctGatherFilesystemType=acct_gather_filesystem/<%= scope['slurm::acctgatherfilesystemtype'] %>
 AcctGatherInfinibandType=acct_gather_infiniband/<%= scope['slurm::acctgatherinfinibandtype'] %>


### PR DESCRIPTION
`AccountingStoreJobComment` option was removed in 21.08 and replaced with `AccountingStoreFlags`, see https://github.com/SchedMD/slurm/blob/b246dd238914803de76fcb69bbe21f2b8e889e5a/NEWS#L917