### PR TITLE
Fix missing spool directory, pidfile location, obsoleted specplugin

### DIFF
--- a/manifests/slurmctld.pp
+++ b/manifests/slurmctld.pp
@@ -29,7 +29,7 @@ class slurm::slurmctld inherits slurm
     'present' => 'directory',
     default   => $slurm::ensure
   }
-  file { $slurm::params::slurmctld_libdir:
+  file { $slurm::statesavelocation:
     ensure => $dir_ensure,
     owner  => $slurm::params::username,
     group  => $slurm::params::group,

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -128,7 +128,7 @@ SlurmdParameters=<%=  scope['slurm::slurmdparameters'].join(',')  %>
 <% end -%>
 SlurmdPidFile=/var/run/slurmd.pid
 SlurmdPort=<%= scope['slurm::slurmdport'] %>
-SlurmdSpoolDir=/var/lib/slurmd
+SlurmdSpoolDir=<%= scope['slurm::statesavelocation'] %>
 <% if scope['slurm::srunepilog'].empty? -%>
 #SrunEpilog=
 <% else -%>
@@ -561,7 +561,9 @@ TopologyPlugin=topology/<%= scope['slurm::topology'] %>
 #######################
 # - Characteristics (sockets, cores, threads, memory, features)
 # - Network addresses
+<% unless scope.call_function('versioncmp', [scope['slurm::version'], '24.05']) >= 0 %>
 CoreSpecPlugin=core_spec/<%= scope['slurm::corespecplugin'] %>
+<% end -%>
 <% unless scope['slurm::cpufreqdef'].nil? -%>
 CpuFreqDef=<%= scope['slurm::cpufreqdef'] %>
 <% end -%>

--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -37,7 +37,7 @@ LogFile=<%= scope['slurm::logdir'] %>/slurmdbd.log
 DebugLevelSyslog=<%= scope['slurm::slurmdbddebugsyslog']%>
 <% end -%>
 
-#PidFile=/var/run/slurmdbd.pid
+PidFile=/var/run/slurmdbd/slurmdbd.pid  # created by RuntimeDirectory options in service
 # Authentication for communications with the other Slurm components
 AuthType=auth/<%= scope['slurm::authtype'] %>
 <% unless scope['slurm::authinfo'].empty? -%>


### PR DESCRIPTION
I combined 3 small problems together in this PR to avoid flooding you. If you'd prefer 3 separate PRs instead I'm happy to break it up.

## Problems fixed in this PR

* corespecplugin is defunct/removed as of 24.05
    `slurmctld: error: The option "CoreSpecPlugin" is defunct, please remove it from slurm.conf`

* pid file location is wrong for 24.x versions (and maybe others) -- this is a hardcoded fix, but I can do `versioncmp` if you prefer
   `slurmdbd: error: Unable to open pidfile '/var/run/slurmdbd.pid': Permission denied`

* The spool directory is not created if not using default libdir
    `slurmctld: fatal: mkdir(/var/spool/slurmctld): Permission denied`

## Possible concerns

I'm listing some open questions I have about the change. I'd love to hear thoughts on better approaches here, and I'm happy to align with whatever you feel is best.

* I changed one hardcoded pidfile location for another. We should probably identify the version where it changed and make it conditional on the version.

* I saw we had two different variables tracking the state directory and I combined them. If it may be desirable to have separate directories then we should adjust the code to create both if they aren't the same.