### PR TITLE
Apply broken when do_build is false

### DIFF
--- a/data/os/RedHat/9.yaml
+++ b/data/os/RedHat/9.yaml
@@ -1,0 +1,5 @@
+---
+# EL9 moves the development packages to these repos
+slurm::package_install_options:
+  - '--enablerepo=plus'
+  - '--enablerepo=crb'

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -33,7 +33,8 @@ class slurm::common {
   }
 
   package { $all_packages:
-    ensure => 'present',
+    ensure          => 'present',
+    install_options => $slurm::package_install_options,
   }
 
   # Prepare the user and group

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,8 @@
 #          Do we perform the build of the Slurm packages from sources or not?
 # @param do_package_install       [Boolean]     Default: true
 #          Do we perform the install of the Slurm packages or not?
+# @param package_install_options  [Array]       Default: []
+#          installation_options for the package resource
 # @param wrappers                 [Array]       Default: [ 'slurm-openlava',  'slurm-torque' ]
 #          Extra wrappers/package to install (ex: openlava/LSF wrapper, Torque/PBS wrappers)
 # @param src_checksum             [String]      Default: ''
@@ -527,6 +529,7 @@ class slurm(
   # Slurm source building
   Boolean $do_build                       = $slurm::params::do_build,
   Boolean $do_package_install             = $slurm::params::do_package_install,
+  Array[String] $package_install_options  = [],  # values from hiera data
   String  $src_checksum                   = $slurm::params::src_checksum,
   String  $src_checksum_type              = $slurm::params::src_checksum_type,
   String  $srcdir                         = $slurm::params::srcdir,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,10 @@ class slurm::install {
       slurmctld => ($slurm::with_slurmctld or defined(Class['::slurm::slurmctld'])),
       slurmdbd  => ($slurm::with_slurmdbd  or defined(Class['::slurm::slurmdbd'])),
       wrappers  => $slurm::wrappers,
-      require   => Slurm::Build[$slurm::version],
+      require   => $slurm::do_build ? {
+        true  => Slurm::Build[$slurm::version],
+        false => undef
+      }
     }
   }
 }


### PR DESCRIPTION
## Fixes

* Dependency installation fails because the level packages are in `crb` and `plus` repositories in EL9
* Setting `do_build` to false causes apply to fail since it's referring to resources within the build block

```
Notice: /Stage[main]/Slurm::Install/Slurm::Build[24.05.2]/Exec[build-slurm-24.05.2]: Dependency Archive[slurm-24.05.2.tar.bz2] has failures: true
```

With this patch it will properly install when the packages are in a DNF/YUM repo.

*This entire build block is a little clunky and could be optimized if you don't mind a refactoring PR*