### PR TITLE
Replace obsolete validate_legacy with data type tests

### DIFF
--- a/manifests/accounting.pp
+++ b/manifests/accounting.pp
@@ -11,18 +11,17 @@
 #
 # Setup the accounting structure
 #
-#@param ensure       [String]  Default: 'present'
-#          Ensure the presence (or absence) of the Munge service
+#@param ensure
+#          Ensure the presence (or absence) of the Munge service - Default: 'present'.
 #
 class slurm::accounting(
-  String  $ensure = $slurm::params::ensure,
-  $cluster        = undef,
-  $qos            = undef,
-  $account        = undef,
+  Enum['present', 'absent'] $ensure  = $slurm::params::ensure,
+  Optional[String]          $cluster = undef,
+  Optional[String]          $qos     = undef,
+  Optional[Stirng]          $account = undef,
 )
 inherits slurm::params
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   ### Clusters
   $clusters = $cluster ? {
     undef   => $slurm::clustername,

--- a/manifests/acct/account.pp
+++ b/manifests/acct/account.pp
@@ -19,8 +19,8 @@
 # and a working SLURMDBD.
 # The name of this resource is expected to be the qos name.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of the entity
+# @param ensure
+#          Ensure the presence (or absence) of the entity - Default: 'present'
 # @param cluster [String] Default: 'cluster'
 #          Cluster name on which the specified resources are to be available
 # @param options [Hash] Default: {}
@@ -32,12 +32,11 @@
 #                          MaxWall=, Names=, Organization=, Parent=,
 #                          and QosLevel=
 define slurm::acct::account(
-  String $ensure  = $slurm::params::ensure,
-  String $cluster = '',
-  Hash   $options = {},
+  Enum['present', 'absent'] $ensure  = $slurm::params::ensure,
+  String                    $cluster = '',
+  Hash                      $options = {},
 )
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   $real_clustername = empty($slurm::clustername) ? {
     true    => '',
     default => $slurm::clustername,

--- a/manifests/acct/cluster.pp
+++ b/manifests/acct/cluster.pp
@@ -13,8 +13,8 @@
 # /!\ WARNING: this assumes you are using the MySQL plugin as SlurmDBD plugin and a working SLURMDBD.
 # The name of this resource is expected to be the cluster name.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of the entity
+# @param ensure
+#          Ensure the presence (or absence) of the entity - Default: 'present'
 # @param options [Hash] Default: {}
 #          Specification options -- see https://slurm.schedmd.com/sacctmgr.html
 #          Elligible keys:  # Classification, Cluster, ClusterNodes,
@@ -34,11 +34,10 @@
 #
 #
 define slurm::acct::cluster(
-  String  $ensure  = $slurm::ensure,
-  Hash    $options = {}
+  Enum['present', 'absent'] $ensure  = $slurm::ensure,
+  Hash                      $options = {}
 )
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   slurm::acct::mgr { "cluster/${name}":
     ensure  => $ensure,
     entity  => 'cluster',

--- a/manifests/acct/mgr.pp
+++ b/manifests/acct/mgr.pp
@@ -15,9 +15,9 @@
 # /!\ WARNING: this assumes you are using the MySQL plugin as SlurmDBD plugin
 # and a working SLURMDBD.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of the cluster
-# @param entity [String]
+# @param ensure
+#          Ensure the presence (or absence) of the cluster - Default: 'present'
+# @param entity
 #          the entity to consider for the name of this resource.
 #          Elligible values in [ 'account',
 #                                'association',
@@ -42,30 +42,15 @@
 #          See https://slurm.schedmd.com/sacctmgr.html
 #
 define slurm::acct::mgr(
-  String $ensure  = $slurm::params::ensure,
-  String $entity  = '',
-  String $value   = '',
-  String $content = '',
-  $options        = undef,
+  Enum['present','absent'] $ensure  = $slurm::params::ensure,
+  Slurm::Entity            $entity  = '',
+  String                   $value   = '',
+  String                   $content = '',
+  Optional[Hash]           $options = undef,
 )
 {
   include ::slurm
   include ::slurm::params
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $entity,
-  [ '^account',
-    '^association',
-    '^cluster',
-    '^coordinator',
-    '^event',
-    '^job',
-    '^qos',
-    '^Resource',
-    '^RunawayJobs',
-    '^stats',
-    '^transaction',
-    '^user',
-    '^wckeys'])
 
   $action = $ensure ? {
     'absent' => 'del',

--- a/manifests/acct/qos.pp
+++ b/manifests/acct/qos.pp
@@ -17,8 +17,8 @@
 # and a working SLURMDBD.
 # The name of this resource is expected to be the qos name.
 #
-# @param ensure      [String]            Default: 'present'
-#          Ensure the presence (or absence) of the entity
+# @param ensure
+#          Ensure the presence (or absence) of the entity  - Default: 'present'
 # @param priority    [Integer]           Default: 0
 # @param options     [Hash]              Default: {}
 #          Specification options -- see https://slurm.schedmd.com/sacctmgr.html
@@ -45,13 +45,12 @@
 #
 # @example
 define slurm::acct::qos(
-  String  $ensure   = $slurm::params::ensure,
-  Integer $priority = 0,
-  String  $content  = '',
-  Hash    $options  = {},
+  Enum['present', 'absent'] $ensure   = $slurm::params::ensure,
+  Integer                   $priority = 0,
+  String                    $content  = '',
+  Hash                      $options  = {},
 )
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   $default_options = {
     'priority' => $priority,
   }

--- a/manifests/acct/user.pp
+++ b/manifests/acct/user.pp
@@ -16,8 +16,8 @@
 # and a working SLURMDBD.
 # The name of this resource is expected to be the qos name.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of the entity
+# @param ensure
+#          Ensure the presence (or absence) of the entity - Default: 'present'
 # @param $defaultaccount [String]
 #          Identify the default bank account name to be used for a job if none is
 #          specified at submission time.
@@ -26,12 +26,11 @@
 #          Elligible keys:
 #
 define slurm::acct::user(
-  String  $ensure         = $slurm::params::ensure,
-  String  $defaultaccount = '',
-  Hash    $options        = {},
+  Enum['present', 'absent'] $ensure         = $slurm::params::ensure,
+  String                    $defaultaccount = '',
+  Hash                      $options        = {},
 )
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   $default_options = empty($defaultaccount) ? {
     true    => {},
     default => { 'DefaultAccount' => $defaultaccount, }

--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -14,8 +14,8 @@
 # This assumes the sources have been downloaded using slurm::download
 #
 #
-# @param ensure  [String]  Default: 'present'
-#          Ensure the presence (or absence) of building
+# @param ensure
+#          Ensure the presence (or absence) of building - Default: 'present'
 # @param srcdir  [String] Default: '/usr/local/src'
 #          Where the [downloaded] Slurm sources are located
 # @param dir     [String] Default: '/root/rpmbuild' on redhat systems
@@ -60,19 +60,21 @@
 #      slurm-torque-19.05.3-2.el7.x86_64.rpm
 #
 define slurm::build(
-  String  $ensure  = $slurm::params::ensure,
-  String  $srcdir  = $slurm::params::srcdir,
-  String  $dir     = $slurm::params::builddir,
-  Array   $with    = $slurm::params::build_with,
-  Array   $without = $slurm::params::build_without,
+  Enum['present', 'absent'] $ensure  = $slurm::params::ensure,
+  String                    $srcdir  = $slurm::params::srcdir,
+  String                    $dir     = $slurm::params::builddir,
+  Array                     $with    = $slurm::params::build_with,
+  Array                     $without = $slurm::params::build_without,
 )
 {
   include ::slurm::params
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $name,   [ '\d+[\.-]?' ])
 
   # $name is provided at define invocation
-  $version = $name
+  $version = $name ? {
+    Pattern[/\d+[\.-]?/] => $name,
+    Integer              => $name,
+    default              => fail("\$name must contain only digits, periods, and dashes")
+  }
 
   # Path to the SLURM sources
   $src = "${srcdir}/slurm-${version}.tar.bz2"

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -14,8 +14,8 @@
 # You can also invoke this definition with the full archive filename i.e.
 # slurm-<version>.tar.bz2.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of building
+# @param ensure
+#          Ensure the presence (or absence) of building - Default: 'present'
 # @param target [String] Default: '/usr/local/src'
 #          Target directory for the downloaded sources
 # @param checksum [String] Default: ''
@@ -35,17 +35,14 @@
 #   }
 #
 define slurm::download(
-  String  $ensure          = $slurm::params::ensure,
-  String  $target          = $slurm::params::srcdir,
-  String  $checksum        = '',
-  String  $checksum_type   = $slurm::params::src_checksum_type,
-  Boolean $checksum_verify = false,
+  Enum['present', 'absent'] $ensure          = $slurm::params::ensure,
+  String                    $target          = $slurm::params::srcdir,
+  String                    $checksum        = '',
+  String                    $checksum_type   = $slurm::params::src_checksum_type,
+  Boolean                   $checksum_verify = false,
 )
 {
   include ::slurm::params
-
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $name,   [ 'slurm-.*\.tar\.bz2', '\d+[\.-]?' ])
 
   # $name is provided at define invocation
   if $name =~ /slurm-(.*)\.tar\.bz2/ {  # Full archive name provided

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -13,15 +13,14 @@
 #
 #
 define slurm::firewall(
-  String $ensure    = 'present',
-  String  $zone     = 'public',
-  $port             = undef,
-  String  $seltype  = '',
-  String  $protocol = 'tcp',
+  Enum['present', 'absent'] $ensure   = 'present',
+  String                    $zone     = 'public',
+  Optional[String]          $port     = undef,
+  String                    $seltype  = '',
+  String                    $protocol = 'tcp',
 )
 {
   include ::slurm::params
-  validate_legacy('String', 'validate_re', $ensure, ['^present', '^absent'])
 
   if (($facts['os']['family'] != 'RedHat') or (versioncmp($facts['os']['release']['major'], '7') < 0)) {
     fail("Module ${module_name} is not supported on ${facts['os']['name']}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,8 +18,8 @@
 #
 # More details on <https://slurm.schedmd.com/>
 #
-# @param ensure [String] Default: 'present'.
-#         Ensure the presence (or absence) of slurm
+# @param ensure
+#         Ensure the presence (or absence) of slurm - Default: 'present'.
 # @param content [String]
 #          The desired contents of a file, as a string. This attribute is
 #          mutually exclusive with source and target.
@@ -507,7 +507,7 @@
 # [Remember: No empty lines between comments and class definition]
 #
 class slurm(
-  String  $ensure                         = $slurm::params::ensure,
+  Enum['present', 'absent'] $ensure       = $slurm::params::ensure,
   $content                                = undef,
   $custom_content                         = undef,
   $source                                 = undef,
@@ -768,8 +768,6 @@ class slurm(
 )
 inherits slurm::params
 {
-  validate_legacy('String', 'validate_re', $ensure, ['^present', '^absent'])
-
   info ("Configuring SLURM (with ensure = ${ensure})")
 
   case $facts['os']['family'] {

--- a/manifests/munge.pp
+++ b/manifests/munge.pp
@@ -25,8 +25,8 @@
 #
 # See https://slurm.schedmd.com/authplugins.html
 #
-# @param ensure       [String]  Default: 'present'
-#          Ensure the presence (or absence) of the Munge service
+# @param ensure
+#          Ensure the presence (or absence) of the Munge service - Default: 'present'
 # @param create_key   [Boolean] Default: true
 #          Whether or not to generate a new key if it does not exists
 # @param daemon_args  [Array] Default: []
@@ -54,21 +54,18 @@
 # does not care about it
 #
 class slurm::munge(
-  String  $ensure         = $slurm::params::ensure,
-  Boolean $create_key     = $slurm::params::munge_create_key,
-  Array $daemon_args      = $slurm::params::munge_daemon_args,
-  Integer $uid            = $slurm::params::munge_uid,
-  Integer $gid            = $slurm::params::munge_gid,
-  String $key_filename    = $slurm::params::munge_key,
-  $key_source             = undef,
-  $key_content            = undef,
-  Boolean $service_manage = $slurm::service_manage,
+  Enum['present', 'absent'] $ensure         = $slurm::params::ensure,
+  Boolean                   $create_key     = $slurm::params::munge_create_key,
+  Array                     $daemon_args    = $slurm::params::munge_daemon_args,
+  Integer                   $uid            = $slurm::params::munge_uid,
+  Integer                   $gid            = $slurm::params::munge_gid,
+  String                    $key_filename   = $slurm::params::munge_key,
+  Optional[String]          $key_source     = undef,
+  Optional[String]          $key_content    = undef,
+  Boolean                   $service_manage = $slurm::service_manage,
 )
 inherits slurm::params
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  #validate_legacy('Boolean', 'validate_bool', $create_key)
-
   if ($facts['os']['family'] == 'RedHat') {
     include ::epel
   }

--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -15,8 +15,8 @@
 #
 # == Parameters
 #
-# @param ensure           [String]  Default: 'present'
-#        Ensure the presence (or absence) of slurm::pam
+# @param ensure
+#        Ensure the presence (or absence) of slurm::pam - Default: 'present'
 # @param allowed_users    [Array]  Default: []
 #        Manage login access (see PAM_ACCESS(8)) in addition to 'root'
 # @param content [String] Default: see 'templates/pam_slurm.erb'
@@ -37,19 +37,16 @@
 # /!\ We assume the RPM 'slurm-pam_slurm' has been already installed
 #
 class slurm::pam(
-  String  $ensure              = $slurm::params::ensure,
-  Array   $allowed_users       = $slurm::params::pam_allowed_users,
-  String  $configfile          = $slurm::params::pam_configfile,
-  String  $content             = $slurm::params::pam_content,
-  Hash    $ulimits             = $slurm::params::ulimits,
-  $ulimits_source              = undef,
-  Boolean $use_pam_slurm_adopt = $slurm::params::use_pam_slurm_adopt,
+  Enum['present', 'absent'] $ensure              = $slurm::params::ensure,
+  Array                     $allowed_users       = $slurm::params::pam_allowed_users,
+  String                    $configfile          = $slurm::params::pam_configfile,
+  String                    $content             = $slurm::params::pam_content,
+  Hash                      $ulimits             = $slurm::params::ulimits,
+  Optional[String]          $ulimits_source      = undef,
+  Boolean                   $use_pam_slurm_adopt = $slurm::params::use_pam_slurm_adopt,
 )
 inherits slurm::params
 {
-  validate_legacy('String', 'validate_re', $ensure, ['^present', '^absent'])
-  validate_legacy('String', 'validate_string', $content)
-
   # PAM access
   # Detect vagrant environment to include 'vagrant' in the list of allowed host otherwise
   # the application of this class will prevent the vagrant user to work as expected

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -11,10 +11,10 @@
 #
 # This definition takes care of managing SLURM plugins.
 #
-# @param ensure [String]  Default: 'present'
-#          Ensure the presence (or absence) of building
-# @param target  [String] Default: '/usr/local/src'
-#          Target directory for the downloaded sources
+# @param ensure
+#          Ensure the presence (or absence) of building - Default: 'present'
+# @param path
+#          Target directory for the downloaded sources - Default '/usr/local/src'
 # @param content [String]      Default: undef
 #           The desired contents of a topology file, as a string. This attribute is
 #           mutually exclusive with topology_source and topology_target.
@@ -26,17 +26,14 @@
 #
 #
 define slurm::plugin(
-  String  $ensure = $slurm::params::ensure,
-  String  $path   = '',
-  $target         = undef,
-  $source         = undef,
-  $content        = undef
+  Enum['present', 'absent']      $ensure  = $slurm::params::ensure,
+  Optional[Stdlib::Absolutepath] $path    = '/usr/local/src',
+  Optional[Stdlib::Absolutepath] $target  = undef,
+  Optional[String]               $source  = undef,
+  Optional[String]               $content = undef,
 )
 {
   include ::slurm::params
-
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  #validate_legacy('String',  'validate_re',   $name,   [ 'slurm-.*\.tar\.bz2', '\d+[\.-]?' ])
 
   # $name is provided at define invocation
   # if $name =~ /slurm-(.*)\.tar\.bz2/ {  # Full archive name provided

--- a/manifests/pmix/build.pp
+++ b/manifests/pmix/build.pp
@@ -14,8 +14,8 @@
 # This assumes the sources have been downloaded using slurm::pmix::download
 #
 #
-# @param ensure  [String]  Default: 'present'
-#          Ensure the presence (or absence) of building
+# @param ensure
+#          Ensure the presence (or absence) of building - Default: 'present'
 # @param srcdir  [String] Default: '/usr/local/src'
 #          Where the [downloaded] Slurm sources are located
 # @param dir     [String] Default: '/root/rpmbuild' on redhat systems
@@ -52,18 +52,20 @@
 # with slurm-libmpi).
 #
 define slurm::pmix::build(
-  String  $ensure  = $slurm::params::ensure,
-  String  $srcdir  = $slurm::params::srcdir,
-  String  $dir     = $slurm::params::builddir,
-  Array   $defines = [],
+  Enum['present', 'absent'] $ensure  = $slurm::params::ensure,
+  String                    $srcdir  = $slurm::params::srcdir,
+  String                    $dir     = $slurm::params::builddir,
+  Array                     $defines = [],
 )
 {
   include ::slurm::params
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $name,   [ '\d+[\.-]?' ])
 
   # $name is provided at define invocation
-  $version = $name
+  $version = $name ? {
+    Pattern[/\d+[\.-]?/] => $name,
+    Integer              => $name,
+    default              => fail("\$name must contain only digits, periods, and dashes")
+  }
 
   # Path to the PMIx sources
   $src = "${srcdir}/pmix-${version}.tar.bz2"

--- a/manifests/pmix/download.pp
+++ b/manifests/pmix/download.pp
@@ -16,8 +16,8 @@
 #
 # Latest PMIx releases: https://github.com/openpmix/openpmix/releases
 #
-# @param ensure       [String]  Default: 'present'
-#          Ensure the presence (or absence) of building
+# @param ensure
+#          Ensure the presence (or absence) of building - Default: 'present'
 # @param target [String] Default: '/usr/local/src'
 #          Target directory for the downloaded sources
 # @param checksum_type [String] Default: 'sha1'
@@ -39,17 +39,15 @@
 #     }
 #
 define slurm::pmix::download(
-  String  $ensure          = $slurm::params::ensure,
-  String  $target          = $slurm::params::srcdir,
-  String  $url             = '',
-  String  $checksum        = '',
-  String  $checksum_type   = $slurm::params::pmix_src_checksum_type,
-  Boolean $checksum_verify = false,
+  Enum['present', 'absent'] $ensure          = $slurm::params::ensure,
+  String                    $target          = $slurm::params::srcdir,
+  String                    $url             = '',
+  String                    $checksum        = '',
+  String                    $checksum_type   = $slurm::params::pmix_src_checksum_type,
+  Boolean                   $checksum_verify = false,
 )
 {
   include ::slurm::params
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $name,   [ '\d+[\.-]?' ])
 
   # $name is provided at define invocation
   if $name =~ /pmix-(.*)\.tar\.bz2/ {  # Full archive name provided

--- a/manifests/pmix/install.pp
+++ b/manifests/pmix/install.pp
@@ -15,8 +15,8 @@
 # incompatible versions of libpmi.so and libpmi2.so.), for a given version for
 # PMIx passed as resource name.
 #
-# @param ensure     [String]  Default: 'present'
-#          Ensure the presence (or absence) of installation
+# @param ensure
+#          Ensure the presence (or absence) of installation - Default: 'present'
 # @param builddir   [String] Default: '/root/rpmbuild/' on redhat systems
 #          Top directory of the sources builds (i.e. RPMs, debs...)
 #          For instance, built RPMs will be placed under
@@ -31,16 +31,18 @@
 #
 #
 define slurm::pmix::install(
-  String  $ensure   = $slurm::params::ensure,
-  String  $builddir = $slurm::params::builddir,
+  Enum['present', 'absent'] $ensure   = $slurm::params::ensure,
+  String                    $builddir = $slurm::params::builddir,
 )
 {
   include ::slurm::params
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
-  validate_legacy('String',  'validate_re',   $name,   [ '\d+[\.-]?' ])
 
   # $name is provided at define invocation
-  $version = $name
+  $version = $name ? {
+    Pattern[/\d+[\.-]?/] => $name,
+    Integer              => $name,
+    default              => fail("\$name must contain only digits, periods, and dashes")
+  }
 
   case $facts['os']['family'] {
     'Redhat': {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,8 +35,8 @@
 #
 # Also, this server is expected to have push writes on the branch 'server/${::hostname}'
 #
-# @param ensure       [String]  Default: 'present'
-#          Ensure the presence (or absence) of the repository
+# @param ensure
+#          Ensure the presence (or absence) of the repository - Default: 'present'
 # @param force        [Boolean] Default: force
 #          Specifies whether to delete any existing files in the repository path
 #          if creating a new repository. Use with care.
@@ -72,22 +72,19 @@
   #  }
 #
 class slurm::repo(
-  String  $ensure      = $slurm::params::ensure,
-  String  $provider    = 'git',
-  String  $basedir     = $slurm::params::repo_basedir,
-  String  $path        = '',
-  $source              = undef,
-  String  $branch      = 'HEAD',
-  String  $syncscript  = '',
-  String  $linkdir     = '',
-  String  $link_subdir = '',
-  Boolean $force       = false,
+  Enum['present', 'absent', 'latest'] $ensure = $slurm::params::ensure,
+  Enum['git', 'bzr', 'hg', 'svn']     $provider    = 'git',
+  String                              $basedir     = $slurm::params::repo_basedir,
+  String                              $path        = '',
+  Optional[String]                    $source      = undef,
+  String                              $branch      = 'HEAD',
+  String                              $syncscript  = '',
+  String                              $linkdir     = '',
+  String                              $link_subdir = '',
+  Boolean                             $force       = false,
 )
 inherits slurm::params
 {
-  validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent', '^latest'])
-  validate_legacy('String',  'validate_re',   $provider, ['^git', '^bzr', '^hg', '^svn'])
-
   if ($source == undef or empty($source)) {
     fail("Module ${module_name} requires a valid source to clone the SLURM control repository")
   }

--- a/manifests/repo/syncto.pp
+++ b/manifests/repo/syncto.pp
@@ -21,14 +21,12 @@
 # @param purge        [Boolean] Default: false
 #          If set, rsync will use '--delete'
 define slurm::repo::syncto(
-  String  $ensure = $slurm::params::ensure,
-  String  $target = '',
-  String  $subdir = '',
-  Boolean $purge  = false,
+  Enum['present', 'absent'] $ensure = $slurm::params::ensure,
+  String                    $target = '',
+  String                    $subdir = '',
+  Boolean                   $purge  = false,
 )
 {
-  validate_legacy('String', 'validate_re', $ensure, ['^present', '^absent'])
-
   include ::slurm::params
   if !defined(Class['slurm::repo']) {
     include ::slurm::repo

--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -17,8 +17,8 @@
 # More details on <https://slurm.schedmd.com/slurmdbd.html>
 # See also <https://slurm.schedmd.com/slurmdbd.conf.html>
 #
-# @param ensure [String] Default: 'present'.
-#         Ensure the presence (or absence) of slurm
+# @param ensure
+#         Ensure the presence (or absence) of slurm - Default: 'present'
 # @param content [String]
 #          The desired contents of a file, as a string. This attribute is
 #          mutually exclusive with source and target.
@@ -131,10 +131,10 @@
 # [Remember: No empty lines between comments and class definition]
 #
 class slurm::slurmdbd(
-  String  $ensure             = $slurm::ensure,
-  $content                    = undef,
-  $source                     = undef,
-  $target                     = undef,
+  Enum['present', 'absent'] $ensure  = $slurm::ensure,
+  Optional[String]          $content = undef,
+  Optional[String]          $source  = undef,
+  Optional[String]          $target  = undef,
   #
   # Main configuration paramaters
   #
@@ -179,8 +179,6 @@ class slurm::slurmdbd(
 )
 inherits slurm
 {
-  validate_legacy('String', 'validate_re', $ensure, ['^present', '^absent'])
-
   case $facts['os']['family'] {
     'Redhat': { }
     default:  { fail("Module ${module_name} is not supported on ${facts['os']['name']}") }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">=4.2.2 <7.0.0"
+      "version_requirement": ">=4.2.2 <10.0.0"
     },
     {
       "name": "puppetlabs-mysql",
@@ -58,7 +58,9 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
@@ -66,14 +68,22 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 9.0.0"
     }
   ],
   "mail": "hpc-team@uni.lu",

--- a/types/entity.pp
+++ b/types/entity.pp
@@ -1,0 +1,1 @@
+type Slurm::Entity = Enum['account', 'association', 'cluster', 'coordinator', 'event', 'job', 'qos', 'Resource', 'RunawayJobs', 'stats', 'transaction', 'user', 'wckeys']


### PR DESCRIPTION
* Remove `validate_legacy` so it works on Puppet 7 and 8.
* Confirmed no problems with modern stdlib
* Add `AlmaLinux` compatibility

In a few cases I added `Optional` types to variables default to undefined, should test that these work properly in numerous situations.