### PR TITLE
Fix slurmd spooldir to be consistent/default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -667,6 +667,7 @@ class slurm (
   Integer $slurmdtimeout                  = $slurm::params::slurmdtimeout,
   Array   $slurmctldparameters            = $slurm::params::slurmctldparameters,
   Array   $slurmdparameters               = $slurm::params::slurmdparameters,
+  String  $slurmdspooldir                 = $slurm::params::slurmdspooldir,
   String  $srunportrange                  = $slurm::params::srunportrange,
   String  $srunepilog                     = $slurm::params::srunepilog,
   String  $srunprolog                     = $slurm::params::srunprolog,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -277,6 +277,7 @@ class slurm::params {
   $slurmdtimeout           = 300
   $slurmctldparameters     = []
   $slurmdparameters        = []
+  $slurmdspooldir          = ''
   $srunportrange           = '50000-53000'
   $srunepilog              = ''
   $srunprolog              = ''

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -128,7 +128,11 @@ SlurmdParameters=<%=  scope['slurm::slurmdparameters'].join(',')  %>
 <% end -%>
 SlurmdPidFile=/var/run/slurmd.pid
 SlurmdPort=<%= scope['slurm::slurmdport'] %>
-SlurmdSpoolDir=<%= scope['slurm::statesavelocation'] %>
+<% if scope['slurm::slurmdspooldir'].empty? -%>
+#SlurmdSpoolDir=
+<% else -%>
+SlurmdSpoolDir=<%= scope['slurm::slurmdspooldir'] %>
+<% end -%>
 <% if scope['slurm::srunepilog'].empty? -%>
 #SrunEpilog=
 <% else -%>


### PR DESCRIPTION
My deepest apologies, I actually broke slurm shared configuration with the change in #70.  Slurmd's spool is distinct from the controller's directory, and when using shared/centralized configuration of slurmd they will all fail since that directory doesn't exist.

Compared to prior-to-70, this revises the approach as follows:
* What was previously hardcoded in the template is now a variable
* It's defined in params like everything else, but with a default value of empty

This default value ensures that the package uses the default value / which would be the directory installed by the package when installed. That value has changed, and is now `/var/spool/slurmd` since v20. It can be overridden by supplying a value, thus ensuring it does the right thing.
