### PR TITLE
DBD CommitDelay broken by apparent mistype

### DIFF
--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -60,7 +60,7 @@ AuthAltParameters=<%= scope['slurm::authaltparameters'].join(',') %>
 # up inserts into the database dramatically.
 # /!\ There is a [very] small probability of data loss
 <% if scope['slurm::slurmdbd::commitdelay'] > 0  -%>
-CommitDelay=<%= scope['slurm::slurmdbpausd::commitdelay'] %>
+CommitDelay=<%= scope['slurm::slurmdbd::commitdelay'] %>
 <% else -%>
 #CommitDelay=<%= scope['slurm::slurmdbd::commitdelay'] %>
 <% end -%>


### PR DESCRIPTION
If you try to set `commitdelay` it's not set due to what appears to be a mistype or mistaken insertion of `paus` into the variable name: https://github.com/ULHPC/puppet-slurm/blob/devel/templates/slurmdbd.conf.erb#L62C1-L63C61

Judged to be a mistake as there's no other reference to this variable.

Appears to be a mistake committed as part of 208d16668db7ab3f74f435d8bc327bd39d3ca9d4 by @Falkor 