### PR TITLE
Add slurmdbd::charset and collate to override mysql module values

### DIFF
--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -100,6 +100,8 @@
 # @param storageport        [Integer]     Default: 3306
 # @param storagetype        [String]      Default: 'mysql'
 # @param storageuser        [String]      Default: 'slurm'
+# @param storagecharset     [String]      Default: undefined  # to override mysql module default
+# @param storagecollate     [String]      Default: undefined  # to override mysql module default
 # @param trackslurmctlddown [Boolean]     Default: false
 #           Boolean yes or no. If set the slurmdbd will mark all idle resources
 #           on the cluster as down when a slurmctld disconnects or is no longer
@@ -168,6 +170,8 @@ class slurm::slurmdbd (
   Integer $storageport        = $slurm::params::storageport,
   String  $storagetype        = $slurm::params::storagetype,
   String  $storageuser        = $slurm::params::storageuser,
+  String  $storagecharset     = undef,
+  String  $storagecollate     = undef,
   Boolean $trackslurmctlddown = $slurm::params::trackslurmctlddown,
   #
   # MySQL settings
@@ -227,6 +231,8 @@ inherits slurm {
       user     => $storageuser,
       password => $storagepass,
       host     => $dbdhost,
+      charset  => $storagecharset,
+      collate  => $storagecollate,
       grant    => ['ALL'],
       before   => File[$slurm::params::dbd_configfile],
     }


### PR DESCRIPTION
The mysql module defaults to `utf8mb3` charset and collate values: https://github.com/puppetlabs/puppetlabs-mysql/blob/main/manifests/db.pp#L54-L55

Some databases accept these values, but report back just `uft8` causing this constant churn:

```
Notice: /Stage[main]/Slurm::Slurmdbd/Mysql::Db[slurm]/Mysql_database[slurm]/charset changed 'utf8' to 'utf8mb3' (corrective)
Notice: /Stage[main]/Slurm::Slurmdbd/Mysql::Db[slurm]/Mysql_database[slurm]/collate changed 'utf8_general_ci' to 'utf8mb3_general_ci' (corrective)
```

This PR allows us to pass the values it expects to the mysql module so as to disable this churn.