### PR TITLE
Minor fixes and proper AcctGatherInterconnect setting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,10 +100,10 @@
 # @param acctgatherfilesystemtype [String]      Default: 'none'
 #          plugin to be used for filesystem traffic accounting.
 #          Elligible values in [ 'none', 'lustre' ]
-# @param acctgatherinfinibandtype      [String]       Default: 'none'
+# @param acctgatherinterconnecttype [String]    Default: 'none'
 #          Identifies the plugin to be used for infiniband network traffic
 #          accounting.
-#          Elligible values in [ 'none', 'ofed' ]
+#          Elligible values in [ 'none', 'ofed', 'sysfs' ]
 # @param acctgatherprofiletype    [String]      Default: 'none'
 #          Plugin to be used for detailed job profiling.
 #          Require to define acct_gather.conf for non-none values
@@ -543,7 +543,7 @@ class slurm (
   Array   $accountingstorageenforce       = $slurm::params::accountingstorageenforce,
   String  $acctgatherenergytype           = $slurm::params::acctgatherenergytype,
   String  $acctgatherfilesystemtype       = $slurm::params::acctgatherfilesystemtype,
-  String  $acctgatherinfinibandtype       = $slurm::params::acctgatherinfinibandtype,
+  String  $acctgatherinterconnecttype     = $slurm::params::acctgatherinterconnecttype,
   String  $acctgatherprofiletype          = $slurm::params::acctgatherprofiletype,
   String  $configdir                      = $slurm::params::configdir,
   String  $clustername                    = $slurm::params::clustername,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,7 +153,7 @@ class slurm::params {
   $accountingstoragetres    = ''
   $acctgatherenergytype     = 'none'
   $acctgatherfilesystemtype = 'none'
-  $acctgatherinfinibandtype = 'none'
+  $acctgatherinterconnecttype = 'none'
   $acctgatherprofiletype    = 'none'
   $batchstarttimeout       = 10
   $getenvtimeout           = 2

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -233,7 +233,7 @@ class slurm::params {
   $priorityweightjobsize   = 0
   $priorityweightpartition = 0
   $priorityweightqos       = 0
-  $privatedata             = []  # in ['accounts','cloud','jobs','nodes','partitions','reservations','usage','users']
+  $privatedata             = []  # in ['accounts','events','jobs','nodes','partitions','reservations','usage','users']
   $proctracktype           = 'cgroup'      # in ['cgroup', 'cray', 'linuxproc', 'lua', 'sgi_job','pgid']
 
   $prolog                  = ''

--- a/manifests/pmix.pp
+++ b/manifests/pmix.pp
@@ -50,15 +50,15 @@ class slurm::pmix (
 ) {
   include slurm::params
 
-  # Download the PMIx sources
-  slurm::pmix::download { $version :
-    ensure        => $ensure,
-    target        => $srcdir,
-    checksum      => $src_checksum,
-    checksum_type => $src_checksum_type,
-  }
-
   if $do_build {
+    # Download the PMIx sources
+    slurm::pmix::download { $version :
+      ensure        => $ensure,
+      target        => $srcdir,
+      checksum      => $src_checksum,
+      checksum_type => $src_checksum_type,
+    }
+
     # Now build them
     slurm::pmix::build { $version :
       ensure  => $ensure,

--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -56,13 +56,13 @@
 # @param archiveusage       [Boolean]     Default: false
 #           When purging usage data (Cluster, Association and WCKey) also archive it.
 # @param commitdelay        [Integer]     Default: 0
-# @param dbhost             [String]      Default: localhost
+# @param dbdhost            [String]      Default: localhost
 #           The short, or long, name of the machine where the Slurm Database Daemon is executed
 # @param dbdbackuphost      [String]      Default: ''
 #           The short, or long, name of the machine where the backup Slurm Database Daemon is executed
 # @param dbdaddr            [String]      Default: localhost
 #           Name that DbdHost should be referred to in establishing a communications path
-# @param dbddport           [Integer]     Default: 6819
+# @param dbdport            [Integer]     Default: 6819
 #           The port number that the Slurm Database Daemon (slurmdbd) listens to for work.
 # @param debuglevel         [String ]     Default: info
 #           The level of detail to provide the Slurm Database Daemon's logs.

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -233,7 +233,7 @@ SlurmdTimeout=<%= scope['slurm::slurmdtimeout'] %>
 UnkillableStepTimeout=<%= scope['slurm::unkillablesteptimeout'] %>
 <% end -%>
 #VSizeFactor=0
-Waittime=<%= scope['slurm::waittime'] %>
+WaitTime=<%= scope['slurm::waittime'] %>
 
 ### POWER SAVE SUPPORT FOR IDLE NODES (optional)
 <% if scope['slurm::suspendprogram'].empty? -%>

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -323,7 +323,7 @@ AccountingStoreFlags=<%= scope['slurm::accountingstoreflags'].join(',') %>
 
 AcctGatherEnergyType=acct_gather_energy/<%=         scope['slurm::acctgatherenergytype'] %>
 AcctGatherFilesystemType=acct_gather_filesystem/<%= scope['slurm::acctgatherfilesystemtype'] %>
-AcctGatherInfinibandType=acct_gather_infiniband/<%= scope['slurm::acctgatherinfinibandtype'] %>
+AcctGatherInterconnectType=acct_gather_interconnect/<%= scope['slurm::acctgatherinterconnecttype'] %>
 AcctGatherProfileType=acct_gather_profile/<%=       scope['slurm::acctgatherprofiletype'] %>
 
 JobAcctGatherFrequency=<%= scope['slurm::jobacctgatherfrequency'] %>

--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -125,7 +125,7 @@ ArchiveUsage=yes
 ####################
 DbdHost=<%= scope['slurm::slurmdbd::dbdhost'] %>
 DbdAddr=<%= scope['slurm::slurmdbd::dbdaddr'] %>
-#DbdPort=<%= scope['slurm::slurmdbdport'] %>
+DbdPort=<%= scope['slurm::slurmdbd::dbdport'] %>
 <% if scope['slurm::slurmdbd::dbdbackuphost'].empty? -%>
 #DbdBackupHost=
 <% else -%>


### PR DESCRIPTION
Short cleanup:
- no need to download pmix sources when not building from source
- Fix setting key s/AcctGatherInfinibandType/AcctGatherInterconnectType/
- And also its value s/acct_gather_infiniband/acct_gather_interconnect/
- Permit customization of slurmdbd listening port