### PR TITLE
[templates/slurm.conf] Add setting AcctGatherNodeFreq

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,7 @@
 #
 # @param accountingstoreflags [Array] Default: []
 #
+# @param acctgathernodefreq      [Integer]     Default: 0
 # @param acctgatherenergytype    [String]      Default: 'none'
 #          Identifies the plugin to be used for energy consumption accounting
 #          Elligible values in [ 'none', 'ipmi', 'rapl' ]
@@ -541,6 +542,7 @@ class slurm (
   # Main configuration paramaters
   #
   Array   $accountingstorageenforce       = $slurm::params::accountingstorageenforce,
+  Integer $acctgathernodefreq             = $slurm::params::acctgathernodefreq,
   String  $acctgatherenergytype           = $slurm::params::acctgatherenergytype,
   String  $acctgatherfilesystemtype       = $slurm::params::acctgatherfilesystemtype,
   String  $acctgatherinterconnecttype     = $slurm::params::acctgatherinterconnecttype,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,6 +151,7 @@ class slurm::params {
   # What level of association-based enforcement to impose on job submissions
   $accountingstorageenforce = ['qos', 'limits', 'associations']
   $accountingstoragetres    = ''
+  $acctgathernodefreq       = 0
   $acctgatherenergytype     = 'none'
   $acctgatherfilesystemtype = 'none'
   $acctgatherinterconnecttype = 'none'

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -321,6 +321,7 @@ AccountingStorageType=accounting_storage/slurmdbd
 AccountingStoreFlags=<%= scope['slurm::accountingstoreflags'].join(',') %>
 <% end -%>
 
+AcctGatherNodeFreq=<%= scope['slurm::acctgathernodefreq'] %>
 AcctGatherEnergyType=acct_gather_energy/<%=         scope['slurm::acctgatherenergytype'] %>
 AcctGatherFilesystemType=acct_gather_filesystem/<%= scope['slurm::acctgatherfilesystemtype'] %>
 AcctGatherInterconnectType=acct_gather_interconnect/<%= scope['slurm::acctgatherinterconnecttype'] %>


### PR DESCRIPTION
https://slurm.schedmd.com/slurm.conf.html#OPT_AcctGatherNodeFreq
> For AcctGather plugin values of none, this parameter is ignored. For
> all other values this parameter is the number of seconds between node
> accounting samples.