### PR TITLE
[security] Sensitive type for storagepass

### DIFF
--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -166,7 +166,7 @@ class slurm::slurmdbd (
   String  $storagehost        = $slurm::params::storagehost,
   String  $storagebackuphost  = $slurm::params::storagebackuphost,
   String  $storageloc         = $slurm::params::storageloc,
-  String  $storagepass        = $slurm::params::storagepass,
+  Variant[Sensitive[String], String] $storagepass = $slurm::params::storagepass,
   Integer $storageport        = $slurm::params::storageport,
   String  $storagetype        = $slurm::params::storagetype,
   String  $storageuser        = $slurm::params::storageuser,
@@ -229,7 +229,7 @@ inherits slurm {
 
     mysql::db { $storageloc:
       user     => $storageuser,
-      password => $storagepass,
+      password => Sensitive($storagepass),
       host     => $dbdhost,
       charset  => $storagecharset,
       collate  => $storagecollate,
@@ -241,7 +241,7 @@ inherits slurm {
     if ($slurm::jobcomptype and $slurm::jobcomptype == 'mysql' and $slurm::jobcomploc and (!empty($slurm::jobcomploc))) {
       mysql::db { $slurm::jobcomploc :
         user     => $storageuser,
-        password => $storagepass,
+        password => Sensitive($storagepass),
         host     => $dbdhost,
         grant    => ['ALL'],
         before   => File[$slurm::params::dbd_configfile],
@@ -252,7 +252,7 @@ inherits slurm {
     unique([$storagehost, $facts['networking']['hostname'], $facts['networking']['fqdn']]).each |String $host| {
       if $host.length < 60 {
         mysql_user { "${storageuser}@${host}":
-          password_hash => mysql::password($storagepass),
+          password_hash => Sensitive(mysql::password($storagepass)),
         }
         mysql_grant { "${storageuser}@${host}/${storageloc}.*":
           privileges => ['ALL'],

--- a/templates/slurmdbd.conf.erb
+++ b/templates/slurmdbd.conf.erb
@@ -169,4 +169,11 @@ StoragePort=<%= scope['slurm::slurmdbd::storageport'] %>
 StorageLoc=<%= scope['slurm::slurmdbd::storageloc'].ljust(12) %>   # Name of the database
 StorageUser=<%= scope['slurm::slurmdbd::storageuser'] %>
 # /!\ Password used to gain access to the database
-StoragePass=<%= scope['slurm::slurmdbd::storagepass'] %>
+<%-
+if scope['slurm::slurmdbd::storagepass'].is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+  storagepass = scope['slurm::slurmdbd::storagepass'].unwrap
+else
+  storagepass = scope['slurm::slurmdbd::storagepass']
+end
+-%>
+StoragePass=<%= storagepass %>


### PR DESCRIPTION
Permit to pass storagepass with Sensitive type.

This commit hides the storagepass from the class attributes inside PuppetDB, but still renders the password visible inside PuppetDB with the generated content of the template.