### PR TITLE
[security] Render slurmdbd.conf template optionally Sensitive

### DIFF
--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -275,7 +275,10 @@ inherits slurm {
   $dbdconf_content = $content ? {
     undef   => $source ? {
       undef   => $target ? {
-        undef   => template('slurm/slurmdbd.conf.erb'),
+        undef   => ($storagepass =~ Sensitive) ? {
+          true  => Sensitive(template('slurm/slurmdbd.conf.erb')),
+          false => template('slurm/slurmdbd.conf.erb'),
+        },
         default => $content,
       },
       default => $content


### PR DESCRIPTION
follow-up 3f3ad77

When passing a Sensitive storagepass to the class, content for the generated template is also defined Sensitive. This way the secret is hidden from PuppetDB.

However there is one downside, the diff is hidden from the `puppet agent` execution, and there is no file kept for diff inside the clientbucket directory.