### PR TITLE
Do not customize gitconfig (#85)

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -128,26 +128,6 @@ inherits slurm::params {
       force  => true,
     }
   }
-  # notice($source)
-  # notice($real_path)
-  if !defined(Git::Config['push.default']) {
-    git::config { 'push.default':
-      value => 'matching',
-      user  => $slurm::params::username,
-    }
-  }
-  if !defined(Git::Config['user.name']) {
-    git::config { 'user.name':
-      value => $slurm::params::comment,
-      user  => $slurm::params::username,
-    }
-  }
-  if !defined(Git::Config['user.email']) {
-    git::config { 'user.email':
-      value => "${slurm::params::username}@${facts['networking']['fqdn']}",
-      user  => $slurm::params::username,
-    }
-  }
 
   vcsrepo { $real_path:
     ensure   => $ensure,


### PR DESCRIPTION
There is no implicit use of customizing gitconfig in this module.

The module uses optionally vcsrepo to clone and pull a repository.

There is no custom script to commit and push changes which can require proper email and username.

Remove this setup from this class. It has to be implemented where specifically required.