### PR TITLE
[manifests/slurmdbd] Bootstrapped MySQL instance defaults always to 127.0.0.1 (#74)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -646,6 +646,7 @@ class slurm::params {
   ##############################
   ### MariaDB configuration  ###
   ##############################
+  $storagehost_bind_address = '127.0.0.1'
   # Buffer Pool Size: 256MB + 256 * log2(RAM size in GB)
   $innodb_buffer_pool_size  = '256M'
   $innodb_log_file_size     = '24M'

--- a/manifests/slurmdbd.pp
+++ b/manifests/slurmdbd.pp
@@ -201,22 +201,11 @@ inherits slurm {
 
   # [Eventually] bootstrap the MySQL DB
   if $bootstrap_mysql {
-    # you now need to  allow remote access from a different host rather than
-    # localhost within /etc/my.cnf.d/server.cnf i.e. $mysql::server::config_file
-    # i.e. comment the line
-    # [mysqld]
-    # ...
-    # bind-address = 127.0.0.1
-    if $storagehost != 'localhost' {
-      $bind_setting = $ensure ? {
-        'present' => '0.0.0.0',
-        default   => '127.0.0.1',
-      }
-    }
+    # Ensure MySQL instance
     class { 'mysql::server':
       override_options => {
         'mysqld' => {
-          'bind-address'             => $bind_setting,
+          'bind-address'             => $slurm::params::storagehost_bind_address,
           # Buffer Pool Size: 256MB + 256 * log2(RAM size in GB)
           'innodb_buffer_pool_size'  => $innodb_buffer_pool_size,
           'innodb_log_file_size'     => $innodb_log_file_size,
@@ -225,8 +214,10 @@ inherits slurm {
       },
     }
 
+    # Ensure clean system users
     include mysql::server::account_security
 
+    # Ensure slurm database
     mysql::db { $storageloc:
       user     => $storageuser,
       password => Sensitive($storagepass),


### PR DESCRIPTION
Fixes https://github.com/ULHPC/puppet-slurm/issues/74

For sack of improvement, make it a variable (should be converted to hiera cf #78.)