### PR TITLE
Use python_version from Hiera for RedHat package installation

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+slurm::python_version: 'python36'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -758,6 +758,7 @@ class slurm (
   # PMIx settings -- see slurm::pmix class
   #
   Boolean $with_pmix                      = $slurm::params::with_pmix,
+  String  $python_version                 = $slurm::params::python_version,
   # String  $pmix_version                   = $slurm::params::pmix_version,
   # String  $pmix_checksum_type             = $slurm::params::pmix_src_checksum_type,
   # String  $pmix_checksum                  = $slurm::params::pmix_src_checksum,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,10 @@ class slurm::params {
   #### MODULE INTERNAL VARIABLES  #########
   # (Modify to adapt to unsupported OSes)
   #########################################
+  # Python version for RedHat systems (e.g., 'python3', 'python36', 'python38')
+  # Value is overridden by slurm class parameter $python_version (from hiera)
+  $python_version = 'python3'
+
   $pre_requisite_packages = $facts['os']['family'] ? {
     'Redhat' => [
       'hwloc', 'hwloc-devel', 'hwloc-plugins', 'numactl', 'numactl-devel',
@@ -38,7 +42,7 @@ class slurm::params {
       'libX11-devel',
       'libssh2-devel',
       'libevent-devel',
-      'python3', 'python3-devel',
+      $python_version, "${python_version}-devel",
     ],
     default => []
   }

--- a/manifests/pmix/build.pp
+++ b/manifests/pmix/build.pp
@@ -52,10 +52,11 @@
 # with slurm-libmpi).
 #
 define slurm::pmix::build (
-  Enum['present', 'absent'] $ensure  = $slurm::params::ensure,
-  String                    $srcdir  = $slurm::params::srcdir,
-  String                    $dir     = $slurm::params::builddir,
-  Array                     $defines = [],
+  Enum['present', 'absent'] $ensure         = $slurm::params::ensure,
+  String                    $srcdir         = $slurm::params::srcdir,
+  String                    $dir            = $slurm::params::builddir,
+  Array                     $defines        = [],
+  String                    $python_version = $slurm::python_version,
 ) {
   include slurm::params
 
@@ -91,13 +92,13 @@ define slurm::pmix::build (
           ensure => 'present',
         }
       }
-      if !defined(Package['python3-devel']) {
-        package { 'python3-devel':
+      if !defined(Package["${python_version}-devel"]) {
+        package { "${python_version}-devel":
           ensure => 'present',
         }
       }
       Yum::Group[$slurm::params::groupinstall] -> Exec[$buildname]
-      Package['libevent-devel'] -> Package['python3-devel'] -> Exec[$buildname]
+      Package['libevent-devel'] -> Package["${python_version}-devel"] -> Exec[$buildname]
 
       $rpmdir = "${dir}/RPMS/${facts['os']['architecture']}"
       $rpms = prefix(suffix($slurm::params::pmix_rpms, "-${version}*.rpm"), "${rpmdir}/")


### PR DESCRIPTION
Add python_version parameter to slurm class, sourced from Hiera (data/os/RedHat.yaml), with defaults in params.pp. Use the variable in pre_requisite_packages and pmix/build.pp to install the correct python and python-devel packages dynamically.