### PR TITLE
fix(plugins): inherit slurm as empty parent

### DIFF
--- a/manifests/plugins/lua.pp
+++ b/manifests/plugins/lua.pp
@@ -15,7 +15,7 @@
 #
 # More details on <https://slurm.schedmd.com/slurm.conf.html>
 #
-class slurm::plugins::lua inherits slurm::plugins {
+class slurm::plugins::lua inherits slurm {
   $lua_content = $slurm::lua_content ? {
     undef   => $slurm::lua_source ? {
       undef   => $slurm::lua_target ? {


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes a regression introduced during modulesync refactor. The class was empty and then removed. However, slurm::plugins::lua was inheriting it.
