### PR TITLE
fix(slurm.conf): remove deprecated getenvtimeout

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -761,11 +761,11 @@ Default value: `$slurm::params::epilogslurmctld`
 
 ##### <a name="-slurm--getenvtimeout"></a>`getenvtimeout`
 
-Data type: `Integer`
+Data type: `Optional[Integer]`
 
 
 
-Default value: `$slurm::params::getenvtimeout`
+Default value: `undef`
 
 ##### <a name="-slurm--grestypes"></a>`grestypes`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,6 +305,7 @@
 #           For use with Slurm's built-in X11 forwarding implementation.
 #           Elligible values in [ 'home_xauthority' ]
 #
+# @param getenvtimeout            [Optional[Integer]] default: undef - deprecated
 ############################                          ################################
 ############################ topology.conf attributes ################################
 ############################                          ################################
@@ -581,7 +582,7 @@ class slurm (
   String  $enforcepartlimits              = $slurm::params::enforcepartlimits,
   String  $epilog                         = $slurm::params::epilog,
   String  $epilogslurmctld                = $slurm::params::epilogslurmctld,
-  Integer $getenvtimeout                  = $slurm::params::getenvtimeout,
+  Optional[Integer] $getenvtimeout        = undef,
   Array   $grestypes                      = $slurm::params::grestypes,
   Integer $healthcheckinterval            = $slurm::params::healthcheckinterval,
   String  $healthchecknodestate           = $slurm::params::healthchecknodestate,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -157,7 +157,6 @@ class slurm::params {
   $acctgatherinterconnecttype = 'none'
   $acctgatherprofiletype    = 'none'
   $batchstarttimeout       = 10
-  $getenvtimeout           = 2
   $checkpointtype          = 'none'  # in ['none', 'ompi']
   $completewait            = 0
   $corespecplugin          = 'none'

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -208,7 +208,9 @@ CompleteWait=<%= scope['slurm::completewait'] %>
 <% end -%>
 
 #EpilogMsgTime=2000
+<% if scope['slurm::getenvtimeout'] -%>
 GetEnvTimeout=<%= scope['slurm::getenvtimeout'] %>
+<% end -%>
 <% if scope['slurm::healthcheckprogram'].empty? %>
 #HealthCheckProgram=/usr/sbin/nhc
 #HealthCheckInterval=30


### PR DESCRIPTION
#### Pull Request (PR) description
`getenvtimeout` parameter is now deprecated, and shouldn't be included in modern config. 
The parameter is still available and will be included if set. But if empty the parameter is just ignored. 

`getenvtimeout` now default to `undef`